### PR TITLE
make rhub build pass

### DIFF
--- a/R/adlib.R
+++ b/R/adlib.R
@@ -271,7 +271,7 @@ format_array <- function(items) {
   if (is.numeric(items)) {
     out <- paste0("[", paste0(items, collapse = ","), "]")
   } else if (is.character(items)) {
-    out <- paste0("[", paste0(shQuote(items), collapse = ","), "]")
+    out <- paste0("[", paste0(shQuote(items, type = 'sh'), collapse = ","), "]")
   }
   else {
     dtype <- class(items)

--- a/tests/testthat/test-requests.R
+++ b/tests/testthat/test-requests.R
@@ -1,6 +1,6 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
 # All rights reserved.
-# 
+#
 # These tests require that a valid access_token is stored in .travis.yml.
 # access tokens eventually expire, so the build will break when that happens.
 # To fix, obtain a long-term access token and add it as an encrypted
@@ -10,10 +10,12 @@
 #    $ travis encrypt FB_GRAPH_API_TOKEN=<access token> --add env.global
 #
 # For local testing just run token_add_to_env() before running the tests.
-token <- Sys.getenv("FB_GRAPH_API_TOKEN")
+
 q <- adlib_build_query("US", search_terms = "president", limit = 3)
 
 test_that("graph_get works", {
+  skip_on_cran()
+  token <- Sys.getenv("FB_GRAPH_API_TOKEN")
   resp <- graph_get("ads_archive", q, token)
   expect_equal(httr::status_code(resp), 200)
   expect_true("data" %in% names(httr::content(resp)))
@@ -21,6 +23,8 @@ test_that("graph_get works", {
 })
 
 test_that("adlib_get works", {
+  skip_on_cran()
+  token <- Sys.getenv("FB_GRAPH_API_TOKEN")
   resp <- adlib_get(q, token = token)
   expect_s3_class(resp, "adlib_data_response")
   resp_table <- tibble::as_tibble(resp, censor_access_token = FALSE)
@@ -28,6 +32,8 @@ test_that("adlib_get works", {
 })
 
 test_that("access token censoring in tibbles works", {
+  skip_on_cran()
+  token <- Sys.getenv("FB_GRAPH_API_TOKEN")
   resp <- adlib_get(q, token = token)
   resp_table <- tibble::as_tibble(resp, censor_access_token = FALSE)
   expect_true(any(detect_access_token(resp_table$ad_snapshot_url)))
@@ -37,6 +43,8 @@ test_that("access token censoring in tibbles works", {
 })
 
 test_that("adlib_get_paginated works", {
+  skip_on_cran()
+  token <- Sys.getenv("FB_GRAPH_API_TOKEN")
   resp <- adlib_get_paginated(q, token = token, max_gets = 2)
   resp_table <- tibble::as_tibble(resp, censor_access_token = FALSE)
   expect_true(tibble::is_tibble(resp_table))


### PR DESCRIPTION
- skip tests that require access_tokens on cran (fixes #50)
- fix quoting on Windows (fixes #51)