### PR TITLE
apply na_pad to both upper and lower bounds for spend and impressions

### DIFF
--- a/R/ad_data.R
+++ b/R/ad_data.R
@@ -162,10 +162,10 @@ ad_row <- function(row) {
       row[[field]] <- NA
     }
   }
-  row[["spend_lower"]] <- as.numeric(row[["spend"]][["lower_bound"]])
+  row[["spend_lower"]] <- as.numeric(na_pad(row[["spend"]][["lower_bound"]]))
   row[["spend_upper"]] <- as.numeric(na_pad(row[["spend"]][["upper_bound"]]))
   row[["adlib_id"]] <- adlib_id_from_row(row)
-  row[["impressions_lower"]] <- as.numeric(row[["impressions"]][["lower_bound"]])
+  row[["impressions_lower"]] <- as.numeric(na_pad(row[["impressions"]][["lower_bound"]]))
   row[["impressions_upper"]] <- as.numeric(na_pad(row[["impressions"]][["upper_bound"]]))
   row[columns]
 }

--- a/tests/testthat/test-requests.R
+++ b/tests/testthat/test-requests.R
@@ -53,3 +53,14 @@ test_that("adlib_get_paginated works", {
   expect_false(any(detect_access_token(tibble::as_tibble(resp, censor_access_token = TRUE)$ad_snapshot_url)))
   expect_true(any(detect_access_token(tibble::as_tibble(resp, censor_access_token = FALSE)$ad_snapshot_url)))
 })
+
+test_that("adlib_get works with no spend or impressions", {
+  skip_on_cran()
+  token <- Sys.getenv("FB_GRAPH_API_TOKEN")
+  q <- adlib_build_query("US",
+    search_terms = "america", limit = 10,
+    fields = c("ad_snapshot_url")
+  )
+  resp <- adlib_get(q, token = token)
+  expect_s3_class(as_tibble(resp, censor_access_token = TRUE), "tbl_df")
+})


### PR DESCRIPTION
resolves #66

test plan:
test "adlib_get works with no spend or impressions" tests this