### PR TITLE
Modify demographic_row & region_row functions to fix the namespace issue

### DIFF
--- a/R/ad_data.R
+++ b/R/ad_data.R
@@ -243,7 +243,7 @@ demographic_row <- function(result_row) {
   demo_row %>%
     purrr::map_df(as_tibble) %>%
     dplyr::mutate(adlib_id = id) %>%
-    dplyr::mutate(percentage = as.numeric(.data$percentage))
+    dplyr::mutate(dplyr::across(dplyr::contains("percentage"), ~ as.numeric(.x)))
 }
 
 #' Turn data from the data field in response content into a demographics table
@@ -269,7 +269,7 @@ region_row <- function(result_row) {
   reg_row %>%
     purrr::map_df(as_tibble) %>%
     dplyr::mutate(adlib_id = id) %>%
-    dplyr::mutate(percentage = as.numeric(.data$percentage))
+    dplyr::mutate(dplyr::across(dplyr::contains("percentage"), ~ as.numeric(.x)))
 }
 
 #' Region Table


### PR DESCRIPTION
Using Dplyr's **across** as a part of the **mutate** transformation seems to fix the issue when the column **percentage** cannot be found within the namespace of these two functions. Importantly, this resulted in an error when using **as_tibble** on demographic and regional data.

Passes the "converting to demographic table" and "converting to region table" test_that tests.

Fixes #87
Fixes #88